### PR TITLE
fix(internal): drop process.env usage

### DIFF
--- a/packages/messenger-internal/src/loader/load-scripts.ts
+++ b/packages/messenger-internal/src/loader/load-scripts.ts
@@ -93,16 +93,14 @@ type Dictionary<K extends keyof any, T> = {
 declare const process: { env: Dictionary<string, string> };
 
 function getManifestUrl(
-  baseUrl = process.env.USERLIKE_WIDGET_URL ??
-    "https://userlike-cdn-widgets.s3-eu-west-1.amazonaws.com"
+  baseUrl = "https://userlike-cdn-widgets.s3-eu-west-1.amazonaws.com"
 ) {
   return `${baseUrl}/umm-manifest.json`;
 }
 
 function getConfigUrl(
   widgetKey: string,
-  baseUrl = process.env.USERLIKE_WIDGET_URL ??
-    "https://userlike-cdn-widgets.s3-eu-west-1.amazonaws.com"
+  baseUrl = "https://userlike-cdn-widgets.s3-eu-west-1.amazonaws.com"
 ) {
   return `${baseUrl}/${widgetKey}.json`;
 }


### PR DESCRIPTION
There was a process.env usage to be able to change base urls of widgets. But that functionality is
already provided via `options` arg. of the API so it's not needed anymore.

Fixes build environments that don't have a mock `process.env` available. 

fix #12