### PR TITLE
feat(internal): extend messenger-api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 tsconfig.tsbuildinfo
 yarn-error.log
 lerna-debug.log
+.vscode

--- a/packages/messenger-internal/CHANGELOG.md
+++ b/packages/messenger-internal/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.2.0-alpha.2](https://github.com/userlike/messenger/compare/@userlike/messenger-internal@2.2.0-alpha.1...@userlike/messenger-internal@2.2.0-alpha.2) (2022-01-25)
+
+
+### Bug Fixes
+
+* remove mention of AuthParams ([a621317](https://github.com/userlike/messenger/commit/a6213170ad5f74bcffe02bdaf398229cbc048a62))
+
+
+### Features
+
+* add openConversationId to mount options ([4a2af88](https://github.com/userlike/messenger/commit/4a2af88d7075c7fa673b27d9737980984b6de75d))
+
+
+
+
+
 # [2.2.0-alpha.1](https://github.com/userlike/messenger/compare/@userlike/messenger-internal@2.2.0-alpha.0...@userlike/messenger-internal@2.2.0-alpha.1) (2022-01-19)
 
 **Note:** Version bump only for package @userlike/messenger-internal

--- a/packages/messenger-internal/CHANGELOG.md
+++ b/packages/messenger-internal/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.2.0-alpha.0](https://github.com/userlike/messenger/compare/@userlike/messenger-internal@2.1.1...@userlike/messenger-internal@2.2.0-alpha.0) (2022-01-19)
+
+
+### Features
+
+* add consumeToken to v1 api ([e9ab784](https://github.com/userlike/messenger/commit/e9ab7847a2d5cd843f17e6eb4ecf93a196fce938))
+* add experimental __unstableOpenConversation to v1 api ([f1e6a76](https://github.com/userlike/messenger/commit/f1e6a76da725579b94adb7afd0fedf236b54b30c))
+* add support for an optional credentials param to v1 api mount ([aad2b7a](https://github.com/userlike/messenger/commit/aad2b7a98de4e65cb1525f60c0fcc3ddaab50b9e))
+
+
+
+
+
 ## [2.1.1](https://github.com/userlike/messenger/compare/@userlike/messenger-internal@2.1.0...@userlike/messenger-internal@2.1.1) (2021-10-05)
 
 

--- a/packages/messenger-internal/CHANGELOG.md
+++ b/packages/messenger-internal/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.2.0-alpha.1](https://github.com/userlike/messenger/compare/@userlike/messenger-internal@2.2.0-alpha.0...@userlike/messenger-internal@2.2.0-alpha.1) (2022-01-19)
+
+**Note:** Version bump only for package @userlike/messenger-internal
+
+
+
+
+
 # [2.2.0-alpha.0](https://github.com/userlike/messenger/compare/@userlike/messenger-internal@2.1.1...@userlike/messenger-internal@2.2.0-alpha.0) (2022-01-19)
 
 

--- a/packages/messenger-internal/package.json
+++ b/packages/messenger-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userlike/messenger-internal",
-  "version": "2.2.0-alpha.1",
+  "version": "2.2.0-alpha.2",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "types": "dist/es/index.d.ts",

--- a/packages/messenger-internal/package.json
+++ b/packages/messenger-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userlike/messenger-internal",
-  "version": "2.1.1",
+  "version": "2.2.0-alpha.0",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "types": "dist/es/index.d.ts",

--- a/packages/messenger-internal/package.json
+++ b/packages/messenger-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userlike/messenger-internal",
-  "version": "2.2.0-alpha.0",
+  "version": "2.2.0-alpha.1",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "types": "dist/es/index.d.ts",

--- a/packages/messenger-internal/src/v1/types.ts
+++ b/packages/messenger-internal/src/v1/types.ts
@@ -10,11 +10,18 @@ export interface ApiState {
   getState(): State;
 }
 
+export interface AuthParams {
+  token: string;
+  uuid: string;
+}
+
 export interface ApiActions {
   /**
    * Create the messenger.
    */
-  mount(): Promise<ActionResult<string, void>>;
+  mount(opts?:  {
+    credentials?: AuthParams;
+  }): Promise<ActionResult<string, void>>;
 
   /**
    * Destroy the messenger.

--- a/packages/messenger-internal/src/v1/types.ts
+++ b/packages/messenger-internal/src/v1/types.ts
@@ -33,6 +33,9 @@ export interface ApiActions {
    */
   consumeToken(token: string): Promise<ActionResult<string, AuthParams>>;
 
+  /**
+   * Control the visibility of messenger features.
+   */
   setVisibility(
     conf: VisibilityConfiguration
   ): Promise<ActionResult<string, void>>;

--- a/packages/messenger-internal/src/v1/types.ts
+++ b/packages/messenger-internal/src/v1/types.ts
@@ -83,6 +83,14 @@ export interface ApiActions {
 
   /**
    * Experimental.
+   * Opens a conversation by id.
+   */
+   __unstableOpenConversation(
+    id: number
+  ): Promise<ActionResult<string, void>>;
+
+  /**
+   * Experimental.
    */
   __unstableSetRegistration(
     enabled: boolean

--- a/packages/messenger-internal/src/v1/types.ts
+++ b/packages/messenger-internal/src/v1/types.ts
@@ -23,6 +23,8 @@ export interface MountOptions {
 export interface ApiActions {
   /**
    * Create the messenger.
+   * When credentials are provided those will be used for authentication.
+   * When openConversationId is passed that conversation will be opened after successful authentication.
    */
   mount(opts?: MountOptions): Promise<ActionResult<string, void>>;
 

--- a/packages/messenger-internal/src/v1/types.ts
+++ b/packages/messenger-internal/src/v1/types.ts
@@ -74,7 +74,7 @@ export interface ApiActions {
 
   /**
    * Experimental.
-   * Consumes a short living token to returns long living AuthParams.
+   * Consumes a short living token to returns long living Credentials.
    */
    __unstableConsumeToken(token: string): Promise<ActionResult<string, Credentials>>;
 

--- a/packages/messenger-internal/src/v1/types.ts
+++ b/packages/messenger-internal/src/v1/types.ts
@@ -32,11 +32,6 @@ export interface ApiActions {
   unmount(): Promise<ActionResult<string, void>>;
 
   /**
-   * Consumes a short living token to returns long living AuthParams.
-   */
-  consumeToken(token: string): Promise<ActionResult<string, Credentials>>;
-
-  /**
    * Control the visibility of messenger features.
    */
   setVisibility(
@@ -74,6 +69,12 @@ export interface ApiActions {
     name?: string;
     email?: string;
   }): Promise<ActionResult<string, void>>;
+
+  /**
+   * Experimental.
+   * Consumes a short living token to returns long living AuthParams.
+   */
+   __unstableConsumeToken(token: string): Promise<ActionResult<string, Credentials>>;
 
   /**
    * Experimental.

--- a/packages/messenger-internal/src/v1/types.ts
+++ b/packages/messenger-internal/src/v1/types.ts
@@ -15,13 +15,16 @@ export interface AuthParams {
   uuid: string;
 }
 
+export interface MountOps {
+  credentials?: AuthParams;
+  openConversationId?: number;
+}
+
 export interface ApiActions {
   /**
    * Create the messenger.
    */
-  mount(opts?:  {
-    credentials?: AuthParams;
-  }): Promise<ActionResult<string, void>>;
+  mount(opts?: MountOps): Promise<ActionResult<string, void>>;
 
   /**
    * Destroy the messenger.

--- a/packages/messenger-internal/src/v1/types.ts
+++ b/packages/messenger-internal/src/v1/types.ts
@@ -17,14 +17,12 @@ export interface Credentials {
 
 export interface MountOptions {
   credentials?: Credentials;
-  openConversationId?: number;
 }
 
 export interface ApiActions {
   /**
    * Create the messenger.
    * When credentials are provided those will be used for authentication.
-   * When openConversationId is passed that conversation will be opened after successful authentication.
    */
   mount(opts?: MountOptions): Promise<ActionResult<string, void>>;
 

--- a/packages/messenger-internal/src/v1/types.ts
+++ b/packages/messenger-internal/src/v1/types.ts
@@ -10,13 +10,13 @@ export interface ApiState {
   getState(): State;
 }
 
-export interface AuthParams {
+export interface Credentials {
   token: string;
   uuid: string;
 }
 
-export interface MountOps {
-  credentials?: AuthParams;
+export interface MountOptions {
+  credentials?: Credentials;
   openConversationId?: number;
 }
 
@@ -24,7 +24,7 @@ export interface ApiActions {
   /**
    * Create the messenger.
    */
-  mount(opts?: MountOps): Promise<ActionResult<string, void>>;
+  mount(opts?: MountOptions): Promise<ActionResult<string, void>>;
 
   /**
    * Destroy the messenger.
@@ -34,7 +34,7 @@ export interface ApiActions {
   /**
    * Consumes a short living token to returns long living AuthParams.
    */
-  consumeToken(token: string): Promise<ActionResult<string, AuthParams>>;
+  consumeToken(token: string): Promise<ActionResult<string, Credentials>>;
 
   /**
    * Control the visibility of messenger features.

--- a/packages/messenger-internal/src/v1/types.ts
+++ b/packages/messenger-internal/src/v1/types.ts
@@ -21,6 +21,11 @@ export interface ApiActions {
    */
   unmount(): Promise<ActionResult<string, void>>;
 
+  /**
+   * Consumes a short living token to returns long living AuthParams.
+   */
+  consumeToken(token: string): Promise<ActionResult<string, AuthParams>>;
+
   setVisibility(
     conf: VisibilityConfiguration
   ): Promise<ActionResult<string, void>>;

--- a/packages/messenger/CHANGELOG.md
+++ b/packages/messenger/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.3-alpha.2](https://github.com/userlike/messenger/compare/@userlike/messenger@1.2.3-alpha.1...@userlike/messenger@1.2.3-alpha.2) (2022-01-25)
+
+**Note:** Version bump only for package @userlike/messenger
+
+
+
+
+
 ## [1.2.3-alpha.1](https://github.com/userlike/messenger/compare/@userlike/messenger@1.2.3-alpha.0...@userlike/messenger@1.2.3-alpha.1) (2022-01-19)
 
 **Note:** Version bump only for package @userlike/messenger

--- a/packages/messenger/CHANGELOG.md
+++ b/packages/messenger/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.3-alpha.0](https://github.com/userlike/messenger/compare/@userlike/messenger@1.2.2...@userlike/messenger@1.2.3-alpha.0) (2022-01-19)
+
+**Note:** Version bump only for package @userlike/messenger
+
+
+
+
+
 ## [1.2.2](https://github.com/userlike/messenger/compare/@userlike/messenger@1.2.1...@userlike/messenger@1.2.2) (2021-10-05)
 
 **Note:** Version bump only for package @userlike/messenger

--- a/packages/messenger/CHANGELOG.md
+++ b/packages/messenger/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.3-alpha.1](https://github.com/userlike/messenger/compare/@userlike/messenger@1.2.3-alpha.0...@userlike/messenger@1.2.3-alpha.1) (2022-01-19)
+
+**Note:** Version bump only for package @userlike/messenger
+
+
+
+
+
 ## [1.2.3-alpha.0](https://github.com/userlike/messenger/compare/@userlike/messenger@1.2.2...@userlike/messenger@1.2.3-alpha.0) (2022-01-19)
 
 **Note:** Version bump only for package @userlike/messenger

--- a/packages/messenger/package.json
+++ b/packages/messenger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userlike/messenger",
-  "version": "1.2.3-alpha.1",
+  "version": "1.2.3-alpha.2",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "types": "dist/es/index.d.ts",
@@ -31,6 +31,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@userlike/messenger-internal": "^2.2.0-alpha.1"
+    "@userlike/messenger-internal": "^2.2.0-alpha.2"
   }
 }

--- a/packages/messenger/package.json
+++ b/packages/messenger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userlike/messenger",
-  "version": "1.2.3-alpha.0",
+  "version": "1.2.3-alpha.1",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "types": "dist/es/index.d.ts",
@@ -31,6 +31,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@userlike/messenger-internal": "^2.2.0-alpha.0"
+    "@userlike/messenger-internal": "^2.2.0-alpha.1"
   }
 }

--- a/packages/messenger/package.json
+++ b/packages/messenger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userlike/messenger",
-  "version": "1.2.2",
+  "version": "1.2.3-alpha.0",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "types": "dist/es/index.d.ts",
@@ -31,6 +31,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@userlike/messenger-internal": "^2.1.1"
+    "@userlike/messenger-internal": "^2.2.0-alpha.0"
   }
 }


### PR DESCRIPTION
This PR extends `@userlike/messenger` v1-api in with regard to authentication and re-authentication in a non-breaking fashion.
As of today those changes are intended for internal usage. Issue: optixx/Userlike/issues/21689

## types (added)
Types for Credentials and MountOptions:
```typescript
interface Credentials {
  token: string;
  uuid: string;
}

interface MountOptions {
  credentials?: Credentials;
  openConversationId?: number;
}
```

## mount (updated)
Optional MountOptions:
```typescript
  /**
   * Create the messenger.
   * When credentials are provided those will be used for authentication.
   * When openConversationId is passed that conversation will be opened after successful authentication.
   */
  mount(opts?: MountOptions): Promise<ActionResult<string, void>>;
```

## consumeToken (unstable/experimental)
Unstable for now so we can test the API internally first.
```typescript
  /**
   * Experimental.
   * Consumes a short living token to returns long living AuthParams.
   */
   __unstableConsumeToken(token: string): Promise<ActionResult<string, Credentials>>;
```
## openConversation (unstable/experimental)
Unstable for now so we can test the API internally first.
```typescript
/**
 * Experimental.
 * Opens a conversation by id.
 */
__unstableOpenConversation(
    id: number
  ): Promise<ActionResult<string, void>>;
```