### PR TITLE
refactor(messenger-internal): remove unnecessary fields from WidgetLoader interface

### DIFF
--- a/packages/messenger-internal/src/loader/types.ts
+++ b/packages/messenger-internal/src/loader/types.ts
@@ -9,11 +9,7 @@ export interface WidgetLoaderSettings {
 }
 
 export interface WidgetLoader {
-  widget_key: string;
-  config: unknown;
-
   load: (opts?: LegacyOptions) => Promise<void>;
-
   createMessenger(
     version: 0
   ): (


### PR DESCRIPTION
BREAKING CHANGE: `widget_key` and `config` fields are removed from `WidgetLoader`.

It's a breaking change only for the `messenger-internal` package and it's breaking only if someone were using those fields. `messenger-internal` is only used by UMF and it doesn't use those fields so this change is safe.