### PR TITLE
feat: contact verification

### DIFF
--- a/packages/messenger-internal/CHANGELOG.md
+++ b/packages/messenger-internal/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.1.0-alpha.0](https://github.com/userlike/messenger/compare/@userlike/messenger-internal@3.0.1-alpha.0...@userlike/messenger-internal@3.1.0-alpha.0) (2024-05-14)
+
+
+### Features
+
+* add contact verification ([aa4b708](https://github.com/userlike/messenger/commit/aa4b70876c6b2b2fe5016c7a7849bb2b7f5cdc94))
+
+
+
+
+
 ## [3.0.1-alpha.0](https://github.com/userlike/messenger/compare/@userlike/messenger-internal@3.0.0...@userlike/messenger-internal@3.0.1-alpha.0) (2024-05-02)
 
 **Note:** Version bump only for package @userlike/messenger-internal

--- a/packages/messenger-internal/package.json
+++ b/packages/messenger-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userlike/messenger-internal",
-  "version": "3.0.1-alpha.0",
+  "version": "3.1.0-alpha.0",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "types": "dist/es/index.d.ts",

--- a/packages/messenger-internal/src/v1/types.ts
+++ b/packages/messenger-internal/src/v1/types.ts
@@ -17,6 +17,10 @@ export interface Credentials {
 
 export interface MountOptions {
   credentials?: Credentials;
+  externalToken?: {
+      getToken: () => Promise<string>;
+      onError?: (e: string) => void;
+  }
 }
 
 export interface ApiActions {

--- a/packages/messenger/CHANGELOG.md
+++ b/packages/messenger/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.5-alpha.1](https://github.com/userlike/messenger/compare/@userlike/messenger@1.2.5-alpha.0...@userlike/messenger@1.2.5-alpha.1) (2024-05-14)
+
+**Note:** Version bump only for package @userlike/messenger
+
+
+
+
+
 ## [1.2.5-alpha.0](https://github.com/userlike/messenger/compare/@userlike/messenger@1.2.4...@userlike/messenger@1.2.5-alpha.0) (2024-05-02)
 
 **Note:** Version bump only for package @userlike/messenger

--- a/packages/messenger/package.json
+++ b/packages/messenger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userlike/messenger",
-  "version": "1.2.5-alpha.0",
+  "version": "1.2.5-alpha.1",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "types": "dist/es/index.d.ts",
@@ -31,6 +31,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@userlike/messenger-internal": "^3.0.1-alpha.0"
+    "@userlike/messenger-internal": "^3.1.0-alpha.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3758,7 +3758,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@userlike/messenger-internal@npm:^3.0.1-alpha.0, @userlike/messenger-internal@workspace:packages/messenger-internal":
+"@userlike/messenger-internal@npm:^3.1.0-alpha.0, @userlike/messenger-internal@workspace:packages/messenger-internal":
   version: 0.0.0-use.local
   resolution: "@userlike/messenger-internal@workspace:packages/messenger-internal"
   languageName: unknown
@@ -3768,7 +3768,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@userlike/messenger@workspace:packages/messenger"
   dependencies:
-    "@userlike/messenger-internal": "npm:^3.0.1-alpha.0"
+    "@userlike/messenger-internal": "npm:^3.1.0-alpha.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Adds support for Contact verification via a signed JWT token.

We now support passing an `externalToken` config when calling `mount()` via messenger api:
```ts
export interface MountOptions {
    ...
    externalToken?: {
        getToken: () => Promise<string>;
        onError?: (e: string) => void;
    }
}
```
The configuration must have a `getToken` callback that returns a fresh JWT whenever invoked. The token payload must be signed using your messenger signing key via `HMAC-SHA256` and must have the following shape :

```ts
interface TokenPayload {
  sub: string; // a unique ID of your choice that you want to use to identify the Contact
  iat: number; // issued at timestamp in Seconds
  exp: number; // expires at timestamp in Seconds
}
```

You can optionally pass an `onError` callback to handle any errors that can happen when creating the JWT.