### PR TITLE
refactor: extend setContactInfo to support more fields

### DIFF
--- a/packages/messenger-internal/CHANGELOG.md
+++ b/packages/messenger-internal/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.2.2-alpha.0](https://github.com/userlike/messenger/compare/@userlike/messenger-internal@3.2.1...@userlike/messenger-internal@3.2.2-alpha.0) (2025-03-24)
+
+**Note:** Version bump only for package @userlike/messenger-internal
+
+
+
+
+
 ## [3.2.1](https://github.com/userlike/messenger/compare/@userlike/messenger-internal@3.2.0...@userlike/messenger-internal@3.2.1) (2024-07-15)
 
 **Note:** Version bump only for package @userlike/messenger-internal

--- a/packages/messenger-internal/package.json
+++ b/packages/messenger-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userlike/messenger-internal",
-  "version": "3.2.1",
+  "version": "3.2.2-alpha.0",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "types": "dist/es/index.d.ts",

--- a/packages/messenger-internal/src/shared/types.ts
+++ b/packages/messenger-internal/src/shared/types.ts
@@ -42,46 +42,40 @@ export interface MessengerActionsApi {
   /**
    * Set custom data.
    */
-  setCustomData(
-    data: Record<string, unknown>,
-  ): Promise<Result< void, string>>;
+  setCustomData(data: Record<string, unknown>): Promise<Result<void, string>>;
 
   /**
    * Set contact info.
    */
-  setContactInfo(
-    data: Partial<ContactInfo>,
-  ): Promise<Result< void, string>>;
+  setContactInfo(data: Partial<ContactInfo>): Promise<Result<void, string>>;
 
   /**
    * Experimental.
    */
-  __unstableStartConversation(): Promise<Result< void, string>>;
+  __unstableStartConversation(): Promise<Result<void, string>>;
 
   /**
    * Experimental.
    */
   __unstableStartConversationWithOperator(
     operatorId: number,
-  ): Promise<Result< void, string>>;
+  ): Promise<Result<void, string>>;
 
   /**
    * Experimental.
    * Opens a conversation by id.
    */
-  __unstableOpenConversation(id: number): Promise<Result< void, string>>;
+  __unstableOpenConversation(id: number): Promise<Result<void, string>>;
 
   /**
    * Experimental.
    */
-  __unstableSetRegistration(
-    enabled: boolean,
-  ): Promise<Result< void, string>>;
+  __unstableSetRegistration(enabled: boolean): Promise<Result<void, string>>;
 
   /**
    * Experimental.
    */
-  __unstableSetProactive(enabled: boolean): Promise<Result< void, string>>;
+  __unstableSetProactive(enabled: boolean): Promise<Result<void, string>>;
 }
 
 export interface State {
@@ -109,6 +103,13 @@ export interface ContactInfo {
   mobile_number: string | null;
   company: string | null;
   external_customer_id: string | null;
+  city: string | null;
+  street: string | null;
+  country: string | null;
+  salutation: "mr" | "ms" | "pr" | "prof" | null;
+  gender: "m" | "f" | "d" | null;
+  custom_field_data: Record<string, null | string | string[]>;
+  instagram_username: string | null;
 }
 
 export interface Message {

--- a/packages/messenger/CHANGELOG.md
+++ b/packages/messenger/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.2-alpha.0](https://github.com/userlike/messenger/compare/@userlike/messenger@1.3.1...@userlike/messenger@1.3.2-alpha.0) (2025-03-24)
+
+**Note:** Version bump only for package @userlike/messenger
+
+
+
+
+
 ## [1.3.1](https://github.com/userlike/messenger/compare/@userlike/messenger@1.3.0...@userlike/messenger@1.3.1) (2024-07-15)
 
 **Note:** Version bump only for package @userlike/messenger

--- a/packages/messenger/package.json
+++ b/packages/messenger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userlike/messenger",
-  "version": "1.3.1",
+  "version": "1.3.2-alpha.0",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "types": "dist/es/index.d.ts",
@@ -31,6 +31,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@userlike/messenger-internal": "^3.2.1"
+    "@userlike/messenger-internal": "^3.2.2-alpha.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3731,7 +3731,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@userlike/messenger-internal@npm:^3.2.1, @userlike/messenger-internal@workspace:packages/messenger-internal":
+"@userlike/messenger-internal@npm:^3.2.2-alpha.0, @userlike/messenger-internal@workspace:packages/messenger-internal":
   version: 0.0.0-use.local
   resolution: "@userlike/messenger-internal@workspace:packages/messenger-internal"
   languageName: unknown
@@ -3741,7 +3741,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@userlike/messenger@workspace:packages/messenger"
   dependencies:
-    "@userlike/messenger-internal": "npm:^3.2.1"
+    "@userlike/messenger-internal": "npm:^3.2.2-alpha.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This PR extends `setContactInfo` to support more default and custom fields.
Closes #39.