### PR TITLE
internal: pass base_url through to run()

### DIFF
--- a/packages/messenger-internal/src/loader/load-scripts.ts
+++ b/packages/messenger-internal/src/loader/load-scripts.ts
@@ -30,7 +30,7 @@ export function loadScripts(
         addScriptSrc(contentDocument, manifest[lastIdx], () => {
           const { run }: Window & { run: Run } = unsafeCoerce(contentWindow);
 
-          run({ widget_key: widgetKey }, window)
+          run({ widget_key: widgetKey, base_url: baseUrl }, window)
             .then((widgetLoader) => resolve(widgetLoader))
             .catch(reject);
         });

--- a/packages/messenger-internal/src/loader/types.ts
+++ b/packages/messenger-internal/src/loader/types.ts
@@ -53,6 +53,7 @@ export interface LegacyOptions {
 
 export interface RunSettings {
   widget_key: string;
+  base_url?: string;
 }
 
 export type Run = (


### PR DESCRIPTION
makes baseUrl available for the messenger bundle know which origin served its loader.

Backwards compatible: baseUrl is optional. Existing umm bundles ignore the new field; bundles that read it fall back to their env-baked URL when older messenger-internal omits it.