### PR TITLE
fix(repo): align release-please tag format with existing tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,16 +2,19 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "include-component-in-tag": true,
+  "include-v-in-tag": false,
   "tag-separator": "@",
   "separate-pull-requests": false,
   "group-pull-request-title-pattern": "chore(release): release ${branch}",
   "plugins": ["node-workspace"],
   "packages": {
     "packages/messenger": {
-      "package-name": "@userlike/messenger"
+      "package-name": "@userlike/messenger",
+      "component": "@userlike/messenger"
     },
     "packages/messenger-internal": {
-      "package-name": "@userlike/messenger-internal"
+      "package-name": "@userlike/messenger-internal",
+      "component": "@userlike/messenger-internal"
     }
   }
 }


### PR DESCRIPTION
## Summary

Fix the wrong-version bumps in the closed PR #62.

release-please was generating tags as `messenger@v2.0.1` — directory-name component + `v` prefix — but the actual repo tags are `@userlike/messenger@2.0.1`. Since release-please couldn't match either format to find the prior release, it fell back to scanning the entire git history and proposed to "re-release" old `feat:` and `BREAKING CHANGE:` commits, producing wrong bumps (messenger 2.0.1 → 2.1.0, messenger-internal 3.3.1 → 4.0.0).

## Changes

- `"include-v-in-tag": false` — drop the `v` prefix
- `"component": "@userlike/messenger"` / `"@userlike/messenger-internal"` — use the full scoped name as the tag component instead of the directory name

Result: release-please's generated tag becomes `@userlike/messenger@<version>` (exactly matching existing tags), so it correctly finds the last release and only scans commits since. Since the recent commits are all `chore:`/`ci:` (non-releasing), release-please should sit idle after this lands.

## Test plan

- [ ] CI passes
- [ ] After merge, watch `release-please.yml` run on master
- [ ] Confirm no new Release PR opens (no releasable commits since 2.0.1 / 3.3.1)