### PR TITLE
fix(repo): include all dist subdirectories in published tarballs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ yarn-error.log
 
 /.yarn/*
 !/.yarn/releases
+*.tgz

--- a/packages/messenger-internal/package.json
+++ b/packages/messenger-internal/package.json
@@ -13,8 +13,8 @@
   },
   "license": "MIT",
   "files": [
-    "dist/es",
-    "dist/cjs"
+    "dist/cjs/**",
+    "dist/es/**"
   ],
   "scripts": {
     "prebuild": "yarn clean",

--- a/packages/messenger/package.json
+++ b/packages/messenger/package.json
@@ -13,9 +13,9 @@
   },
   "license": "MIT",
   "files": [
-    "dist/es",
-    "dist/cjs",
-    "dist/browser"
+    "dist/cjs/**",
+    "dist/es/**",
+    "dist/browser/**"
   ],
   "scripts": {
     "prebuild": "yarn clean",


### PR DESCRIPTION
## :warning: Critical

The 3.3.2 / 2.0.2 tarballs currently staged on npmjs.com are **broken** and must not be approved. Discard them.

`@userlike/messenger-internal@3.3.2` staged tarball contains only `dist/cjs/index.js` and `dist/es/index.js` (5 total files). Its CJS entry `require()`s sibling files (`./shared/Result`, `./loader`, `./legacy-loader`, `./v0`, `./v1`, `./v2`, etc.) that **aren't in the tarball**. Anyone running `npm install @userlike/messenger-internal@3.3.2` would hit "Cannot find module" on first import.

`@userlike/messenger@2.0.2` has the same problem and is additionally missing `dist/browser/index.min.js` (the UMD bundle for `<script>` tag use).

## Root cause

`yarn pack` (yarn 4) does NOT recursively expand directory entries in `package.json` `files` — a literal `"dist/cjs"` matches only the top-level files of that directory, not its subdirectories.

The pre-migration flow shipped via `lerna publish` → `npm publish`, which expanded directories recursively, so this worked. Switching to `yarn pack` broke it silently.

## Fix

Both packages now use explicit `**` globs in `files`:

```diff
- "files": ["dist/cjs", "dist/es"]
+ "files": ["dist/cjs/**", "dist/es/**"]
```

(plus `"dist/browser/**"` for messenger).

Verified locally: yarn pack now produces a 64-file tarball for messenger-internal (all subdirs intact, no tsbuildinfo leak) and includes the UMD bundle in messenger.

Also added `*.tgz` to `.gitignore` so we don't accidentally commit leftover tarballs from local verification.

## Versions

This is a `fix:` commit touching both packages → release-please will bump 3.3.1 → **3.3.3** (skipping the broken 3.3.2) and 2.0.1 → **2.0.3** (skipping the broken 2.0.2).

## Test plan

- [ ] Discard staged 3.3.2 / 2.0.2 on npmjs.com (do not approve)
- [ ] Merge this PR
- [ ] release-please opens Release PR for 3.3.3 / 2.0.3
- [ ] After publish.yml stages and approval, verify tarballs include all expected files